### PR TITLE
refactor(NodeCard): Adjust the display position of custom tags and price info in NodeCard

### DIFF
--- a/src/components/NodeCard.vue
+++ b/src/components/NodeCard.vue
@@ -140,17 +140,6 @@ const customTags = computed(() => {
           <NIcon class="shrink-0">
             <img :src="`/images/flags/${getRegionCode(props.node.region)}.svg`" :alt="getRegionDisplayName(props.node.region)">
           </NIcon>
-          <!-- 自定义标签显示在节点名前 -->
-          <div v-if="customTags.length > 0" class="flex shrink-0 flex-wrap gap-1 items-center">
-            <NTag
-              v-for="(tag, index) in customTags"
-              :key="index"
-              size="small"
-              :color="{ color: `${tag.color}20`, textColor: tag.color, borderColor: `${tag.color}40` }"
-            >
-              {{ tag.text }}
-            </NTag>
-          </div>
           <NEllipsis class="text-lg font-bold m-0 flex-1 min-w-0">
             {{ props.node.name }}
           </NEllipsis>
@@ -300,6 +289,16 @@ const customTags = computed(() => {
               运行时间
             </NText>
             <div class="flex gap-2 items-center">
+              <NText class="text-[13px]" :style="{ fontFamily: appStore.numberFontFamily }">
+                {{ formatUptime(props.node.uptime ?? 0) }}
+              </NText>
+            </div>
+          </div>
+
+          <!-- 标签、剩余时间及价格信息 -->
+          <div class="flex-between">
+            <div class="flex gap-2 items-center">
+              <!-- 剩余时间及价格信息 -->
               <NTag
                 v-for="(tag, index) in priceTags"
                 :key="index"
@@ -308,9 +307,17 @@ const customTags = computed(() => {
               >
                 {{ tag.text }}
               </NTag>
-              <NText class="text-[13px]" :style="{ fontFamily: appStore.numberFontFamily }">
-                {{ formatUptime(props.node.uptime ?? 0) }}
-              </NText>
+              <!-- 自定义标签 -->
+              <div v-if="customTags.length > 0">
+                <NTag
+                  v-for="(tag, index) in customTags"
+                  :key="index"
+                  size="small"
+                  :color="{ color: `${tag.color}20`, textColor: tag.color, borderColor: `${tag.color}40` }"
+                >
+                  {{ tag.text }}
+                </NTag>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
作者您好，非常感谢您的辛勤付出，这是一款非常不错的komari主题。

在1.0.7版本您增加了custom tags及price info展示，不过当把运行时间精确到秒后，NodeCard中的运行时间一行会因为时间字符串过长导致不必要的换行，影响观感，如下图：
<img width="467" height="455" alt="1" src="https://github.com/user-attachments/assets/a52dc156-dcf7-40e6-9b59-bb5186375b1a" />

所以我斗胆对此项目提出PR，修改了custom tags及price info展示位置，将其均展示在运行时间一行之下，不知是否可行？修改后效果如图：
<img width="464" height="474" alt="2" src="https://github.com/user-attachments/assets/314b751f-fc95-4de8-b5a6-60d88de9d38a" />

